### PR TITLE
[feat] Add different logins for Admins, Guests

### DIFF
--- a/app/src/main/java/org/testingTool/controllers/LoginController.java
+++ b/app/src/main/java/org/testingTool/controllers/LoginController.java
@@ -10,4 +10,9 @@ public class LoginController {
   public String loginPage() {
     return "login";
   }
+
+  @GetMapping("/admin/login")
+  public String adminLoginPage() {
+    return "admin_login";
+  }
 }


### PR DESCRIPTION
Это пулл реквест обновляет SecurityConfig так, чтобы авторизация/аунтефикация админов и пользователей были различными процессами и использовали различные authenticationProviders.

1. Удалил authenticationManager.
2. Разделил securityFilterChain на два - один для админов, другой для пользователей.
3. Вернул CSRF защиту на место, однако временно отключил для app-controller.